### PR TITLE
Fix: TypeError: 'NoneType' object is not callable

### DIFF
--- a/erpnext_demo/utils.py
+++ b/erpnext_demo/utils.py
@@ -48,7 +48,7 @@ def make_demo_user():
 
 	def add_roles(doc):
 		for role in roles:
-			p.append("user_roles", {
+			doc.append("user_roles", {
 				"doctype": "UserRole",
 				"role": role
 			})


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/erpnext/bench/env/bin/frappe", line 9, in <module>
    load_entry_point('frappe==4.0.0-beta', 'console_scripts', 'frappe')()
  File "/usr/erpnext/bench/apps/frappe/frappe/cli.py", line 49, in main
    run(fn, parsed_args)
  File "/usr/erpnext/bench/apps/frappe/frappe/cli.py", line 70, in run
    out = globals().get(fn)(_args.get(fn), *_args)
  File "/usr/erpnext/bench/apps/frappe/frappe/cli.py", line 63, in new_fn
    return fn(_args, *_new_kwargs)
  File "/usr/erpnext/bench/apps/frappe/frappe/cli.py", line 269, in install_app
    install_app(app_name, verbose=verbose)
  File "/usr/erpnext/bench/apps/frappe/frappe/installer.py", line 112, in install_app
    frappe.get_attr(after_install)()
  File "/usr/erpnext/bench/erpnext-demo/erpnext_demo/utils.py", line 34, in make_demo
    make_demo_user()
  File "/usr/erpnext/bench/erpnext-demo/erpnext_demo/utils.py", line 67, in make_demo_user
    add_roles(p)
  File "/usr/erpnext/bench/erpnext-demo/erpnext_demo/utils.py", line 53, in add_roles
    "role": role
TypeError: 'NoneType' object is not callable
